### PR TITLE
Simulation config and Game Bootstrap initialization

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1361,6 +1361,52 @@ Light:
   m_LightUnit: 1
   m_LuxAtDistance: 1
   m_EnableSpotReflector: 1
+--- !u!1 &1967256453
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1967256455}
+  - component: {fileID: 1967256454}
+  m_Layer: 0
+  m_Name: _Bootstrap
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1967256454
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1967256453}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5abfc22e20ec3426abb124483075152b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _simulationConfig: {fileID: 11400000, guid: 8edf1492af8134599a51605209c5ff8e, type: 2}
+  _agentConfig: {fileID: 11400000, guid: d11b8b877ea6f450a8921a008927f35c, type: 2}
+--- !u!4 &1967256455
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1967256453}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 6.190976, y: -4.8141875, z: -4.2312746}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2032760887 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: f8d73908c687f4379be8c1a952f0533c, type: 3}
@@ -1473,3 +1519,4 @@ SceneRoots:
   - {fileID: 1116259749}
   - {fileID: 1379625185}
   - {fileID: 2060067927}
+  - {fileID: 1967256455}

--- a/Assets/ScriptableObjects.meta
+++ b/Assets/ScriptableObjects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c4447b82ace9d499083cd3987a5834ba
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/AgentConfig.asset
+++ b/Assets/ScriptableObjects/AgentConfig.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4b90fef7495dc4bee933a52a1da18de6, type: 3}
+  m_Name: AgentConfig
+  m_EditorClassIdentifier: 

--- a/Assets/ScriptableObjects/AgentConfig.asset.meta
+++ b/Assets/ScriptableObjects/AgentConfig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d11b8b877ea6f450a8921a008927f35c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/SimulationConfig.asset
+++ b/Assets/ScriptableObjects/SimulationConfig.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb08b12b8dc464514a681bc6dd54ab77, type: 3}
+  m_Name: SimulationConfig
+  m_EditorClassIdentifier: 

--- a/Assets/ScriptableObjects/SimulationConfig.asset.meta
+++ b/Assets/ScriptableObjects/SimulationConfig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8edf1492af8134599a51605209c5ff8e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/GameBootstrap.cs
+++ b/Assets/Scripts/Core/GameBootstrap.cs
@@ -49,10 +49,7 @@ public sealed class GameBootstrap : MonoBehaviour
             {
             if (_validationService != null)
             {
-                // Fixme: Implementar validaciones
-                // En este issue, la validación puede ser trivial (dimensiones > 0 cuando existan).
-                // Dejará de ser trivial cuando agreguemos Grid.
-                // _validationService.RunAll();  // Descomentar cuando tenga implementación
+                Debug.LogWarning("[GameBootstrap] Validación no implementada aún. Saltando validaciones iniciales.");
             }
             }
             catch (System.Exception ex)

--- a/Assets/Scripts/Core/GameBootstrap.cs
+++ b/Assets/Scripts/Core/GameBootstrap.cs
@@ -11,6 +11,55 @@ using UnityEngine;
 /// - Usa <see cref="ValidationService"/> para sanity checks.
 /// </remarks>
 public sealed class GameBootstrap : MonoBehaviour
-{
-        
-}
+    {
+        [Header("Configs (SO)")]
+        [SerializeField] private SimulationConfig _simulationConfig;
+        [SerializeField] private AgentConfig _agentConfig;
+
+        [Header("Servicios opcionales")]
+        [SerializeField] private ValidationService _validationService; // puede ser null al inicio
+
+        public static GameBootstrap Instance { get; private set; }
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Debug.LogWarning("[GameBootstrap] Duplicado detectado. Destruyendo este objeto.");
+                Destroy(gameObject);
+                return;
+            }
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+
+            // 1) Validar referencias mínimas
+            if (_simulationConfig == null)
+                Debug.LogError("[GameBootstrap] Falta SimulationConfig asignado en el inspector.");
+            if (_agentConfig == null)
+                Debug.LogError("[GameBootstrap] Falta AgentConfig asignado en el inspector.");
+
+            // 2) Registrar configs y servicios mínimos
+            ServiceRegistry.Clear(); // Limpiar escena
+            if (_simulationConfig != null) ServiceRegistry.Register(_simulationConfig);
+            if (_agentConfig != null) ServiceRegistry.Register(_agentConfig);
+            if (_validationService != null) ServiceRegistry.Register(_validationService);
+
+            // 3) Validaciones iniciales (solo configuración, sin grid)
+            try
+            {
+            if (_validationService != null)
+            {
+                // Fixme: Implementar validaciones
+                // En este issue, la validación puede ser trivial (dimensiones > 0 cuando existan).
+                // Dejará de ser trivial cuando agreguemos Grid.
+                // _validationService.RunAll();  // Descomentar cuando tenga implementación
+            }
+            }
+            catch (System.Exception ex)
+            {
+                Debug.LogError($"[GameBootstrap] Validaciones fallaron: {ex.Message}");
+            }
+
+            Debug.Log("[GameBootstrap] Inicializado. Configs y servicios registrados.");
+        }
+    }

--- a/Assets/Scripts/Core/ServiceRegistry.cs
+++ b/Assets/Scripts/Core/ServiceRegistry.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// Registro simple de servicios a nivel proceso/escena.
+/// Permite registrar y resolver dependencias sin acoplar a un IoC container pesado.
+/// </summary>
+public static class ServiceRegistry
+{
+    /// <summary>
+    /// Mapa de servicios registrados. Por ejemplo, 
+    /// <see cref="SimulationConfig"/> o <see cref="AgentConfig"/>.
+    /// </summary>
+    private static readonly Dictionary<Type, object> _map = new();
+
+    /// <summary>
+    /// Registra una instancia de servicio en el contenedor.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="instance"></param>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static void Register<T>(T instance) where T : class
+    {
+        if (instance == null) throw new ArgumentNullException(nameof(instance));
+        _map[typeof(T)] = instance;
+    }
+
+    
+    public static bool TryResolve<T>(out T service) where T : class
+    {
+        if (_map.TryGetValue(typeof(T), out var obj))
+        {
+            service = (T)obj;
+            return true;
+        }
+        service = null;
+        return false;
+    }
+
+    public static T Resolve<T>() where T : class
+    {
+        if (!TryResolve<T>(out var s))
+            throw new InvalidOperationException($"Service not found: {typeof(T).Name}");
+        return s;
+    }
+
+    public static bool IsRegistered<T>() where T : class => _map.ContainsKey(typeof(T));
+
+    public static void Clear() => _map.Clear();
+}
+

--- a/Assets/Scripts/Core/ServiceRegistry.cs.meta
+++ b/Assets/Scripts/Core/ServiceRegistry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 58e415da2277444a0befeaffa0fb7881


### PR DESCRIPTION
#1 #11 
This pull request introduces a foundational structure for configuration management and service registration in the Unity project. The main changes include the addition of a `GameBootstrap` MonoBehaviour for initializing core configurations and services, a lightweight `ServiceRegistry` for dependency management, and new ScriptableObject assets for simulation and agent configuration. These updates lay the groundwork for scalable and maintainable scene setup and dependency handling.

**Core System Initialization:**

* Added `GameBootstrap` MonoBehaviour (`Assets/Scripts/Core/GameBootstrap.cs`) to initialize and validate essential configuration ScriptableObjects (`SimulationConfig`, `AgentConfig`) and optional services, enforce singleton pattern, and register them with the new service registry. It also provides error handling and logging for missing references.

**Service Registry Implementation:**

* Introduced `ServiceRegistry` static class (`Assets/Scripts/Core/ServiceRegistry.cs`) for simple runtime registration, resolution, and management of services and configuration objects, decoupling dependency management from scene objects.

**Configuration Assets:**

* Created new ScriptableObject assets for `SimulationConfig` and `AgentConfig` (`Assets/ScriptableObjects/SimulationConfig.asset`, `Assets/ScriptableObjects/AgentConfig.asset`) and their associated `.meta` files, enabling inspector-based configuration. [[1]](diffhunk://#diff-3c6d2d65259cb21c30942cde18d78d114135e20b6e33d384e2087c5847d4c489R1-R14) [[2]](diffhunk://#diff-9e99dfb17d5b07f1902f29d9efd5b8e20f5aeb173289ac2d900034305c8b77a2R1-R8) [[3]](diffhunk://#diff-e566a47cbf1d88095ff2e8640d033eb2c6a9e0a825870c5af437dfe1cdb85c58R1-R14) [[4]](diffhunk://#diff-d6f0f3c712d2c8440f63f4c6fe66b82ff0a179ec52c4f9681a776ff6d6b85d29R1-R8)
* Added `Assets/ScriptableObjects.meta` to register the new folder in the project.

**Scene Integration:**

* Updated `SampleScene.unity` to add a `_Bootstrap` GameObject with the `GameBootstrap` MonoBehaviour, linking the new configuration assets and ensuring it is part of the scene root objects for proper initialization. [[1]](diffhunk://#diff-3119c4ae6706a16c12a3ff6c05a377defc6e122a4ddd378164a1053a831a4f75R1364-R1409) [[2]](diffhunk://#diff-3119c4ae6706a16c12a3ff6c05a377defc6e122a4ddd378164a1053a831a4f75R1522)