### PR TITLE
Added cell classes and enums (with QA Tests in the TestingSystem)

### DIFF
--- a/Assets/Scripts/Debug.meta
+++ b/Assets/Scripts/Debug.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 67c61c12c0ba5422486fff8c62a606bc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Debug/TestGridCell.cs
+++ b/Assets/Scripts/Debug/TestGridCell.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 public class TestGridCell : MonoBehaviour
 {
-    // Start is called once before the first execution of Update after the MonoBehaviour is created
+    // Triggers the grid cell testing system when the MonoBehaviour is created
     void Start()
     {
         QATestingSystem.TestGridCell();

--- a/Assets/Scripts/Debug/TestGridCell.cs
+++ b/Assets/Scripts/Debug/TestGridCell.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+
+public class TestGridCell : MonoBehaviour
+{
+    // Start is called once before the first execution of Update after the MonoBehaviour is created
+    void Start()
+    {
+        QATestingSystem.TestGridCell();
+    }
+}

--- a/Assets/Scripts/Debug/TestGridCell.cs.meta
+++ b/Assets/Scripts/Debug/TestGridCell.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e5385ecba38a3472bb064f3c532bfb66

--- a/Assets/Scripts/Grid/GridCell.cs
+++ b/Assets/Scripts/Grid/GridCell.cs
@@ -1,15 +1,88 @@
 using UnityEngine;
-
+using System;
 /// <summary>
-/// Unidad lógica del mapa (tipo de celda, ocupación, costo de tránsito).
-/// Representación pura (sin dependencias de Unity) para facilitar pruebas.
+/// Unidad lógica del mapa. Clase pura (sin MonoBehaviour).
+/// Contiene el tipo de celda (estático), un costo base de tránsito y
+/// una máscara de ocupación para estados dinámicos (robot/joya/zona/reserva).
 /// </summary>
 /// <remarks>
 /// Interacciones:
-/// - Contenida en <see cref="GridMap"/> y expuesta por <see cref="GridService"/>.
-/// - Leída por <see cref="PathfindingService"/> al calcular costos y bloqueos.
+/// - Será contenida por <see cref="GridMap"/> (Issue #3).
+/// - Consultada por <see cref="GridService"/> y <see cref="PathfindingService"/>.
+/// - Mutada por sistemas de spawn, movimiento y reserva de celdas.
 /// </remarks>
 public sealed class GridCell
 {
-        
+    /// <summary>Tipo "fijo" de la celda (muro, estante, vacía, zona, etc.).</summary>
+    public CellType Type { get; private set; }
+
+    /// <summary>Ocupación dinámica como bitmask (robot, joya, zona, reservado).</summary>
+    public CellOccupant Occupants { get; private set; }
+
+    /// <summary>
+    /// Indica si por tipo la celda es transitable (no muro/estante).
+    /// No considera la ocupación dinámica (robots/reservas).
+    /// </summary>
+    public bool IsWalkableByType =>
+        Type != CellType.Wall && Type != CellType.Shelf;
+
+    /// <summary>
+    /// Indica si la celda está actualmente bloqueada para moverse (ocupación/reserva).
+    /// No evalúa el tipo; para check completo usa <see cref="IsWalkableNow"/>.
+    /// </summary>
+    public bool IsBlockedByOccupant =>
+        Occupants.HasFlag(CellOccupant.Robot) || Occupants.HasFlag(CellOccupant.Reserved);
+
+    /// <summary>
+    /// Resultado práctico: ¿se puede entrar a esta celda en este momento?
+    /// Considera tipo + ocupación/reserva.
+    /// </summary>
+    public bool IsWalkableNow => IsWalkableByType && !IsBlockedByOccupant;
+
+    /// <summary>Crea una celda con tipo dado y ocupación opcional.</summary>
+    public GridCell(CellType type = CellType.Empty, CellOccupant occupants = CellOccupant.None)
+    {
+        Type = type;
+        Occupants = occupants;
+    }
+
+    /// <summary>Cambia el tipo de la celda. No modifica ocupación ni costo.</summary>
+    public void SetType(CellType type) => Type = type;
+
+    /// <summary>Agrega un flag de ocupación (bitwise OR).</summary>
+    public void AddOccupant(CellOccupant o) => Occupants |= o;
+
+    /// <summary>Remueve un flag de ocupación (bitwise AND NOT).</summary>
+    public void RemoveOccupant(CellOccupant o) => Occupants &= ~o;
+
+    /// <summary>True si el flag indicado está presente.</summary>
+    public bool HasOccupant(CellOccupant o) => Occupants.HasFlag(o);
+
+    /// <summary>Elimina toda ocupación.</summary>
+    public void ClearOccupants() => Occupants = CellOccupant.None;
+
+    public override string ToString()
+        => $"GridCell(Type={Type}, WalkableByType={IsWalkableByType}, Occupants={Occupants})";
+}
+
+/// <summary>Tipos "estructurales" de la celda.</summary>
+public enum CellType
+{
+    Empty = 0,
+    Wall = 1,
+    Shelf = 2,
+    Jewel = 3, // tipo visual/lógico del terreno; la joya real también será un ocupante
+    Zone = 4,
+    RobotSpawn = 5
+}
+
+/// <summary>Ocupantes dinámicos (bitmask). Pueden coexistir múltiples flags.</summary>
+[Flags]
+public enum CellOccupant
+{
+    None     = 0,
+    Robot    = 1 << 0, // bloquea paso a otros robots
+    Jewel    = 1 << 1, // no bloquea (se puede recoger)
+    Zone     = 1 << 2, // no bloquea
+    Reserved = 1 << 3  // bloquea temporalmente (mediador de colisiones)
 }

--- a/Assets/Scripts/Systems/QATestingSystem.cs
+++ b/Assets/Scripts/Systems/QATestingSystem.cs
@@ -28,6 +28,6 @@ public static class QATestingSystem
         cell.SetType(CellType.Wall);
         UnityEngine.Debug.Log(cell.IsWalkableNow); // false por tipo (muro)
 
-        Debug.Log("[QATestingSystem] Todas las pruebas para GridCell completadas.");
+        Debug.Log("[QATestingSystem] All tests for GridCell completed.");
     }
 }

--- a/Assets/Scripts/Systems/QATestingSystem.cs
+++ b/Assets/Scripts/Systems/QATestingSystem.cs
@@ -9,7 +9,7 @@ public static class QATestingSystem
 
     public static void TestGridCell()
     {
-        Debug.Log("[QATestingSystem] Iniciando pruebas para GridCell.");
+        Debug.Log("[QATestingSystem] Starting tests for GridCell.");
 
         // Prueba de creación de celdas
         var cell = new GridCell(CellType.Empty);

--- a/Assets/Scripts/Systems/QATestingSystem.cs
+++ b/Assets/Scripts/Systems/QATestingSystem.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+
+public static class QATestingSystem
+{
+    public static void RunAllTests()
+    {
+        TestGridCell();
+    }
+
+    public static void TestGridCell()
+    {
+        Debug.Log("[QATestingSystem] Iniciando pruebas para GridCell.");
+
+        // Prueba de creación de celdas
+        var cell = new GridCell(CellType.Empty);
+        Debug.Assert(cell.Type == CellType.Empty, "[QATestingSystem] Error: Tipo de celda no coincide.");
+
+        // Prueba de ocupantes
+        cell.AddOccupant(CellOccupant.Robot);
+        Debug.Assert(cell.HasOccupant(CellOccupant.Robot), "[QATestingSystem] Error: Robot no encontrado como ocupante.");
+
+        UnityEngine.Debug.Log(cell.IsWalkableNow); // true
+
+        cell.AddOccupant(CellOccupant.Robot);
+        UnityEngine.Debug.Log(cell.IsWalkableNow); // false
+
+        cell.RemoveOccupant(CellOccupant.Robot);
+        cell.SetType(CellType.Wall);
+        UnityEngine.Debug.Log(cell.IsWalkableNow); // false por tipo (muro)
+
+        Debug.Log("[QATestingSystem] Todas las pruebas para GridCell completadas.");
+    }
+}

--- a/Assets/Scripts/Systems/QATestingSystem.cs.meta
+++ b/Assets/Scripts/Systems/QATestingSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 16e6b322d4fad483c80df582d103562f


### PR DESCRIPTION
Resolves #2 
This pull request introduces a new system for unit testing the core grid cell logic and refactors the `GridCell` class to support more flexible and testable cell state management. The changes add a pure (non-MonoBehaviour) implementation of grid cells with clear separation of static type and dynamic occupancy, and implement a simple QA testing system to validate cell behaviors in isolation.

**Grid Cell Logic and Structure:**

* Refactored `GridCell` in `Grid/GridCell.cs` to be a pure class (no MonoBehaviour), with explicit fields for cell type (`CellType` enum) and dynamic occupants (`CellOccupant` bitmask), plus utility methods for querying and mutating occupancy and walkability.
* Added new enums `CellType` and `[Flags] CellOccupant` to define structural cell types and dynamic occupancy flags, supporting future extensibility and easy unit testing.

**Testing and Debugging Infrastructure:**

* Introduced `QATestingSystem` in `Systems/QATestingSystem.cs` as a static class for running automated tests on grid cells, including creation, occupancy mutation, and walkability checks.
* Added `Debug/TestGridCell.cs` MonoBehaviour for triggering grid cell tests via Unity's lifecycle, enabling in-editor validation.